### PR TITLE
Fix a few gym links in Town page.

### DIFF
--- a/pages/Towns/main.html
+++ b/pages/Towns/main.html
@@ -45,7 +45,7 @@
         <div data-bind="foreach: $data.content">
             <!-- ko if: $data.__proto__.constructor.name == "Gym" -->
                 <a class="badge text-bg-secondary" href="#!" data-bind="text: $data.__proto__.constructor.name + ': ' + $data.buttonText, 
-                attr: { href: `#!Gyms/${!$data.buttonText.includes('Elite') && !$data.buttonText.includes('Supreme') && !$data.buttonText.includes('Champion')? Wiki.pageName() : $data.buttonText}` }"></a>
+                attr: { href: `#!Gyms/${$data.town}` }"></a>
             <!-- /ko -->
             <!-- ko ifnot: $data.__proto__.constructor.name == "Gym" -->
                 <span class="badge text-bg-secondary" data-bind="text: GameConstants.camelCaseToString($data.__proto__.constructor.name.replace(/(MoveTo|TownContent|Temporary)/, ''))"></span>


### PR DESCRIPTION
So weird that there is no template...

The gym link in town was incorrect for Circhester gyms and Cipher Admin gyms (and a few paldean gyms ? But it did not matter yet). Luckily the Gym instance has a `gym.town` attribute to match the actual links with. It even means the special check for League stuff is obsolete

No testing, to be honest, I just ran a script on the live version of the Wiki. The gym page link is built using its key (`gymName`) in `GymList`, and this code ensured that no gym had a `gymName` different to its registered `gym.town`.
```js
Object.entries(GymList).filter(([gymName, gymObj]) => gymName !== gymObj.town);```